### PR TITLE
fix req.session typecheck fail

### DIFF
--- a/auth/package.json
+++ b/auth/package.json
@@ -22,7 +22,7 @@
   "license": "ISC",
   "dependencies": {
     "@hntickets/common": "^1.0.4",
-    "@types/cookie-session": "^2.0.39",
+    "@types/cookie-session": "^2.0.40",
     "@types/express": "^4.17.6",
     "@types/jsonwebtoken": "^8.5.0",
     "@types/mongoose": "^5.7.21",

--- a/auth/src/routes/signin.ts
+++ b/auth/src/routes/signin.ts
@@ -42,9 +42,7 @@ router.post(
       process.env.JWT_KEY!
     );
 
-    req.session = {
-      jwt: userJwt,
-    };
+    req.session!.jwt = userJwt;
 
     res.status(200).send(existingUser);
   }

--- a/auth/src/routes/signup.ts
+++ b/auth/src/routes/signup.ts
@@ -37,9 +37,7 @@ router.post(
       process.env.JWT_KEY!
     );
 
-    req.session = {
-      jwt: userJwt,
-    };
+    req.session!.jwt = userJwt;
 
     res.status(201).send(user);
   }


### PR DESCRIPTION
In #2  we discover that github ci uses different @types/cookie-session version then our local machine, This new version has new SessionObject interface. 

I decided to use the newer types. This mean we can't override req.session object, instead we pass jwt as a new property to req.session. We can assume session object will always be defined looking at the new interface